### PR TITLE
Integration Specs are not a metric

### DIFF
--- a/tasks/metrics/ci.rake
+++ b/tasks/metrics/ci.rake
@@ -1,12 +1,11 @@
 # encoding: utf-8
 
-desc 'Run metrics with Mutant'
-task ci: %w[ ci:metrics metrics:mutant ]
+desc 'Run all metrics and integration specs'
+task ci: %w[ ci:metrics metrics:mutant spec:integration ]
 
 namespace :ci do
   tasks = %w[
     metrics:coverage
-    spec:integration
     metrics:yardstick:verify
     metrics:rubocop
     metrics:flog
@@ -14,6 +13,6 @@ namespace :ci do
     metrics:reek
   ]
 
-  desc 'Run metrics (except mutant) and spec'
+  desc 'Run metrics (except mutant)'
   task metrics: tasks
 end


### PR DESCRIPTION
Hey :smile: 

I disagree a little with the way that devtools defines the different CI tasks :warning: This is extremely nitpicky :warning: 

The CI namespace contains the following tasks:
- `metrics:coverage`
- `spec:integration`
- `metrics:yardstick:verify`
- `metrics:rubocop`
- `metrics:flog`
- `metrics:flay`
- `metrics:reek`

This is awesome, I totally agree with this. **But** the `ci:metrics` executes all of them – including the integration tests. Integration tests are not a metric and should therefore not be run here. This is also apparent from the description of the task "Run metrics (except mutant) and spec". The `ci` task then has to run the acceptance tests of course :wink: 

I know, this is super nitpicky :blush: 
