### PR TITLE
Reek Output

### DIFF
--- a/tasks/metrics/reek.rake
+++ b/tasks/metrics/reek.rake
@@ -9,6 +9,7 @@ namespace :metrics do
 
     if config.enabled?
       Reek::Rake::Task.new do |reek|
+        reek.reek_opts     = '--quiet'
         reek.fail_on_error = Devtools.master?
         reek.config_files  = config.config_file.to_s
         reek.source_files  = '{app,lib}/**/*.rb'


### PR DESCRIPTION
Currently, the output of Reek is quite verbose. I think I remember that we once talked about the output of metrics and we all said that the output should be as minimal as possible: If there are violations, tell me the violations. Otherwise: Don't tell me anything (or "Ok" – but only once, not for every file) :wink: 

Is this possible with Reek? The current output for Ashikawa::Core is:

```
lib/ashikawa-core.rb -- 0 warnings
lib/ashikawa-core/collection.rb -- 0 warnings
lib/ashikawa-core/configuration.rb -- 0 warnings
lib/ashikawa-core/connection.rb -- 0 warnings
lib/ashikawa-core/cursor.rb -- 0 warnings
lib/ashikawa-core/database.rb -- 0 warnings
lib/ashikawa-core/document.rb -- 0 warnings
lib/ashikawa-core/edge.rb -- 0 warnings
lib/ashikawa-core/exceptions/client_error.rb -- 0 warnings
lib/ashikawa-core/exceptions/client_error/bad_syntax.rb -- 0 warnings
lib/ashikawa-core/exceptions/client_error/resource_not_found.rb -- 0 warnings
lib/ashikawa-core/exceptions/client_error/resource_not_found/collection_not_found.rb -- 0 warnings
lib/ashikawa-core/exceptions/client_error/resource_not_found/document_not_found.rb -- 0 warnings
lib/ashikawa-core/exceptions/client_error/resource_not_found/index_not_found.rb -- 0 warnings
lib/ashikawa-core/exceptions/no_collection_provided.rb -- 0 warnings
lib/ashikawa-core/exceptions/server_error.rb -- 0 warnings
lib/ashikawa-core/exceptions/server_error/json_error.rb -- 0 warnings
lib/ashikawa-core/figure.rb -- 0 warnings
lib/ashikawa-core/index.rb -- 0 warnings
lib/ashikawa-core/key_options.rb -- 0 warnings
lib/ashikawa-core/query.rb -- 0 warnings
lib/ashikawa-core/request_preprocessor.rb -- 0 warnings
lib/ashikawa-core/response_preprocessor.rb -- 0 warnings
lib/ashikawa-core/status.rb -- 0 warnings
lib/ashikawa-core/transaction.rb -- 0 warnings
lib/ashikawa-core/version.rb -- 0 warnings
0 total warnings
```
