### PR TITLE
Upgrade Rubocop to 0.13.0

### DIFF
--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -34,7 +34,7 @@ group :metrics do
   gem 'flay',      '~> 2.4.0'
   gem 'flog',      '~> 4.1.1'
   gem 'reek',      '~> 1.3.2'
-  gem 'rubocop',   '~> 0.12.0'
+  gem 'rubocop',   '~> 0.13.0'
   gem 'simplecov', '~> 0.7.1'
   gem 'yardstick', '~> 0.9.7', git: 'https://github.com/dkubb/yardstick.git'
 


### PR DESCRIPTION
Just a tiny version bump for the just-released Rubocop. Some nice new cops in there. See [changelog](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md)
