### PR TITLE
Add Guard-JRuby-RSpec

### DIFF
--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -15,10 +15,11 @@ group :yard do
 end
 
 group :guard do
-  gem 'guard',         '~> 2.2.4'
-  gem 'guard-bundler', '~> 2.0.0'
-  gem 'guard-rspec',   '~> 4.0.4'
-  gem 'guard-rubocop', '~> 1.0.0'
+  gem 'guard',             '~> 2.2.4'
+  gem 'guard-bundler',     '~> 2.0.0'
+  gem 'guard-rspec',       '~> 4.0.4'
+  gem 'guard-jruby-rspec', '~> 0.2',  platform: :jruby
+  gem 'guard-rubocop',     '~> 1.0.0'
 
   # file system change event handling
   gem 'listen',     '~> 2.2.0'


### PR DESCRIPTION
Though guard-rspec tests against JRuby, it allows it to fail.

-  https://github.com/jkutner/guard-jruby-rspec

I'm not sure if other changes in any templates would be necessary

cc @jkutner 