### PR TITLE
Make coverage task execute unit specs, even if already run.

### DIFF
--- a/tasks/metrics/coverage.rake
+++ b/tasks/metrics/coverage.rake
@@ -5,7 +5,7 @@ namespace :metrics do
   task :coverage do
     begin
       original, ENV['COVERAGE'] = ENV['COVERAGE'], 'true'
-      Rake::Task['spec:unit'].invoke
+      Rake::Task['spec:unit'].execute
     ensure
       ENV['COVERAGE'] = original
     end


### PR DESCRIPTION
`metrics:coverage` currently uses `Rake::Task['spec:unit'].invoke`, which is a no-op if the specs have already been run.  This results in coverage being foregone when, e.g. `rake ci` is invoked.

The issue is reproducible by comparing the output of `rake metrics:coverage` to `rake spec:unit metrics:coverage`.  I believe we'd expect the latter to run the specs once and if they pass, run them again with coverage.  I think using #execute is the simplest way to make that happen, but maybe i'm missing something?

[This commit](https://github.com/rom-rb/devtools/commit/dc3710c55718f16848857acc8951ed06134f517b) from March switched from #execute to #invoke; it wasn't clear why since that didn't seem to be the primary purpose of the commit.

Please let me know if there's a more preferable way to bring such minor issues to your attention.  Thanks!