### PR TITLE
Allow Flog enabled platforms to be configurable.

### DIFF
--- a/lib/devtools/config.rb
+++ b/lib/devtools/config.rb
@@ -137,9 +137,11 @@ module Devtools
     # Flog configuration
     class Flog < self
       FILE = 'flog.yml'.freeze
+      DEFAULT_ENABLED_PLATFORMS = ['mri-1.9.3'].freeze
 
       attribute :total_score
       attribute :threshold
+      attribute :enabled_platforms, DEFAULT_ENABLED_PLATFORMS
     end
 
     # Mutant configuration

--- a/tasks/metrics/flog.rake
+++ b/tasks/metrics/flog.rake
@@ -8,9 +8,7 @@ namespace :metrics do
     project = Devtools.project
     config  = project.flog
 
-    compatible_scores = %w(mri-1.9.3)
-
-    if ! compatible_scores.include?(Devtools.rvm)
+    if ! config.enabled_platforms.include?(Devtools.rvm)
       task :flog do
         $stderr.puts "Flog is disabled under #{Devtools.rvm}"
       end


### PR DESCRIPTION
Minor change to allow configuration of platforms under which flog is enabled.  Moves currently hard-coded `mri-1.9.3` option into a default in `config.rb` and changes `flog.rake` to read the setting.  Projects wishing to configure this would add, e.g:

```
# config/flog.yml
enabled_platforms: [mri-2.0.0, mri-1.9.3]
```

I'm not sure if _enabled_platforms_ is the correct term to use since `flog.rake` currently uses _compatible_scores_.  The former seems more intuitive to me but also implies a wider scope.  Happy to change the terms as you see fit.
