### PR TITLE
Change `Config::Yardstick#options` to skip `nil` values.

### DIFF
--- a/lib/devtools/config.rb
+++ b/lib/devtools/config.rb
@@ -129,7 +129,7 @@ module Devtools
       # @api private
       def options
         OPTIONS.each_with_object({}) { |name, hash|
-          hash[name] = raw.fetch(name, nil)
+          hash[name] = raw[name] if raw.key?(name)
         }
       end
     end


### PR DESCRIPTION
The `yardstick` rake tasks currently don't work for any `devtools` enabled projects that rely on default configuration options.  This is caused by a mismatch between interfaces: 

* `Devtools::Config::Yardstick#options` returns a hash containing all available options, with `nil` values for any that aren't specified in `config/yardstick.yml`
* `Yardstick::Config#defaults=` takes this hash and attempts to set defaults, but doesn't recognize any of the options with `nil` values as needing a default.

This PR changes `Devtools::Config::Yardstick#options` to return a hash containing only options that have values specified in `config/yardstick.yml` so that `yardstick` can set defaults for the rest.

**Warning**: this change may unearth documentation deficiencies and break builds for any `devtools` enabled projects!