### PR TITLE
Fixed broken globbing introduced in d45bfc4594

### DIFF
--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -17,7 +17,7 @@ begin
   namespace :spec do
     desc 'Run unit specs'
     RSpec::Core::RakeTask.new(:unit) do |task|
-      task.pattern = 'spec/unit/*/**/*_spec.rb'
+      task.pattern = 'spec/unit/**/*_spec.rb'
     end
 
     desc 'Run integration specs'


### PR DESCRIPTION
This will remove a obsolete `*/` in the glob for the unit spec files. This caused unit specs to fail in a very weird way. I didn't investigated further why this error occurred and I don't think it is required for this patch ^^.
