### PR TITLE
Use Gemfile, not gemspec, for dependencies

### DIFF
--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |gem|
   gem.test_files            = `git ls-files -- spec`.split($/)
   gem.extra_rdoc_files      = %w[README.md TODO]
   gem.required_ruby_version = '>= 2.0.0'
+
+  gem.add_development_dependency 'bundler', '~> 1.7.10'
 end

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files      = %w[README.md TODO]
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_dependency 'bundler', '~> 1.7.6'
+  gem.add_dependency 'bundler', '~> 1.5'
 end

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -16,19 +16,4 @@ Gem::Specification.new do |gem|
   gem.test_files            = `git ls-files -- spec`.split($/)
   gem.extra_rdoc_files      = %w[README.md TODO]
   gem.required_ruby_version = '>= 2.0.0'
-
-  gem.add_dependency 'rspec',        '~> 3.1.0'
-  gem.add_dependency 'rspec-core',   '~> 3.1.7'
-  gem.add_dependency 'rspec-its',    '~> 1.1.0'
-  gem.add_dependency 'rake',         '~> 10.4.0'
-  gem.add_dependency 'yard',         '~> 0.8.7.6'
-  gem.add_dependency 'coveralls',    '~> 0.7.2'
-  gem.add_dependency 'flay',         '~> 2.5.0'
-  gem.add_dependency 'flog',         '~> 4.3.0'
-  gem.add_dependency 'reek',         '=  1.4.0'  # locked due to buggy ast processing
-  gem.add_dependency 'rubocop',      '~> 0.28.0'
-  gem.add_dependency 'simplecov',    '~> 0.9.1'
-  gem.add_dependency 'yardstick',    '~> 0.9.9'
-  gem.add_dependency 'mutant',       '~> 0.7.4'
-  gem.add_dependency 'mutant-rspec', '~> 0.7.4'
 end

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files      = %w[README.md TODO]
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_development_dependency 'bundler', '~> 1.7.10'
+  gem.add_dependency 'bundler', '~> 1.7.6'
 end

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -37,7 +37,7 @@ group :metrics do
   gem 'simplecov', '~> 0.9.1'
   gem 'yardstick', '~> 0.9.9'
 
-  platforms :mri do
+  platforms :mri_20, :mri_21, :ruby_22 do
     gem 'mutant',       '~> 0.7.4'
     gem 'mutant-rspec', '~> 0.7.4'
   end

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -1,4 +1,10 @@
 group :development do
+  gem 'rake',       '~> 10.4.0'
+  gem 'rspec',      '~> 3.1.0'
+  gem 'rspec-core', '~> 3.1.7'
+  gem 'rspec-its',  '~> 1.1.0'
+  gem 'yard',       '~> 0.8.7.6'
+
   platform :rbx do
     gem 'rubysl-singleton', '~> 2.0.0'
   end
@@ -23,6 +29,19 @@ group :guard do
 end
 
 group :metrics do
+  gem 'coveralls', '~> 0.7.2'
+  gem 'flay',      '~> 2.5.0'
+  gem 'flog',      '~> 4.3.0'
+  gem 'reek',      '=  1.4.0'  # locked due to buggy ast processing
+  gem 'rubocop',   '~> 0.28.0'
+  gem 'simplecov', '~> 0.9.1'
+  gem 'yardstick', '~> 0.9.9'
+
+  platforms :mri do
+    gem 'mutant',       '~> 0.7.4'
+    gem 'mutant-rspec', '~> 0.7.4'
+  end
+
   platform :rbx do
     gem 'json',               '~> 1.8.1'
     gem 'racc',               '~> 1.4.12'

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -37,7 +37,7 @@ group :metrics do
   gem 'simplecov', '~> 0.9.1'
   gem 'yardstick', '~> 0.9.9'
 
-  platforms :mri_20, :mri_21, :ruby_22 do
+  platforms :mri_20, :mri_21 do
     gem 'mutant',       '~> 0.7.4'
     gem 'mutant-rspec', '~> 0.7.4'
   end


### PR DESCRIPTION
I think this is the superior option for the following reasons:
* Gemfile provides more fine-grained options for choosing when to install a dependency
* The dependencies can be more easily tailored by the client project by editing Gemfile.devtools
* devtools doesn't actually need all the extra 'dependencies' to provide its core functionality of installing a special Gemfile setup