### PR TITLE
Remove redundant ruby version guards

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
-threshold: 8
-total_score: 94
+threshold: 16
+total_score: 97

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables           = %w[devtools]
   gem.test_files            = `git ls-files -- spec`.split($/)
   gem.extra_rdoc_files      = %w[README.md TODO]
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.1'
 
   gem.add_dependency 'rspec',        '~> 3.3.0'
   gem.add_dependency 'rspec-core',   '~> 3.3.0'

--- a/lib/devtools/config.rb
+++ b/lib/devtools/config.rb
@@ -126,22 +126,9 @@ module Devtools
     class Flog < self
       FILE                      = 'flog.yml'.freeze
       DEFAULT_LIB_DIRS          = %w[lib].freeze
-      DEFAULT_ENABLED_PLATFORMS = %w[
-        mri-2.0.0
-        mri-2.1.0
-        mri-2.1.1
-        mri-2.1.2
-        mri-2.1.3
-        mri-2.1.4
-        mri-2.1.5
-        mri-2.2.0
-        mri-2.2.1
-        mri-2.2.2
-      ].freeze
 
       attribute :total_score
       attribute :threshold
-      attribute :enabled_platforms, DEFAULT_ENABLED_PLATFORMS
       attribute :lib_dirs,          DEFAULT_LIB_DIRS
     end
 

--- a/tasks/metrics/flay.rake
+++ b/tasks/metrics/flay.rake
@@ -6,62 +6,43 @@ namespace :metrics do
   project = Devtools.project
   config  = project.flay
 
-  compatible_scores = %w[
-    mri-2.0.0
-    mri-2.1.0
-    mri-2.1.1
-    mri-2.1.2
-    mri-2.1.3
-    mri-2.1.4
-    mri-2.1.5
-    mri-2.2.0
-    mri-2.2.1
-    mri-2.2.2
-  ].freeze
+  # Original code by Marty Andrews:
+  # http://blog.martyandrews.net/2009/05/enforcing-ruby-code-quality.html
+  desc 'Measure code duplication'
+  task :flay do
+    threshold   = config.threshold
+    total_score = config.total_score
+    files       = Flay.expand_dirs_to_files(config.lib_dirs).sort
 
-  if !compatible_scores.include?(Devtools.rvm)
-    task :flay do
-      $stderr.puts "Flay is disabled under #{Devtools.rvm}"
+    # Run flay first to ensure the max mass matches the threshold
+    flay = Flay.new(fuzzy: false, verbose: false, mass: 0)
+    flay.process(*files)
+    flay.analyze
+
+    masses = flay.masses.map do |hash, mass|
+      Rational(mass, flay.hashes[hash].size)
     end
-  else
-    # Original code by Marty Andrews:
-    # http://blog.martyandrews.net/2009/05/enforcing-ruby-code-quality.html
-    desc 'Measure code duplication'
-    task :flay do
-      threshold   = config.threshold
-      total_score = config.total_score
-      files       = Flay.expand_dirs_to_files(config.lib_dirs).sort
 
-      # Run flay first to ensure the max mass matches the threshold
-      flay = Flay.new(fuzzy: false, verbose: false, mass: 0)
-      flay.process(*files)
-      flay.analyze
+    max = (masses.max || 0).to_i
+    unless max >= threshold
+      Devtools.notify_metric_violation "Adjust flay threshold down to #{max}"
+    end
 
-      masses = flay.masses.map do |hash, mass|
-        Rational(mass, flay.hashes[hash].size)
-      end
+    total = masses.inject(:+).to_i
+    unless total == total_score
+      Devtools.notify_metric_violation "Flay total is now #{total}, but expected #{total_score}"
+    end
 
-      max = (masses.max || 0).to_i
-      unless max >= threshold
-        Devtools.notify_metric_violation "Adjust flay threshold down to #{max}"
-      end
+    # Run flay a second time with the threshold set
+    flay = Flay.new(fuzzy: false, verbose: false, mass: threshold.succ)
+    flay.process(*files)
+    flay.analyze
 
-      total = masses.inject(:+).to_i
-      unless total == total_score
-        Devtools.notify_metric_violation "Flay total is now #{total}, but expected #{total_score}"
-      end
+    mass_size = flay.masses.size
 
-      # Run flay a second time with the threshold set
-      flay = Flay.new(fuzzy: false, verbose: false, mass: threshold.succ)
-      flay.process(*files)
-      flay.analyze
-
-      mass_size = flay.masses.size
-
-      if mass_size.nonzero?
-        flay.report
-        Devtools.notify_metric_violation "#{mass_size} chunks have a duplicate mass > #{threshold}"
-      end
+    if mass_size.nonzero?
+      flay.report
+      Devtools.notify_metric_violation "#{mass_size} chunks have a duplicate mass > #{threshold}"
     end
   end
 end

--- a/tasks/metrics/flog.rake
+++ b/tasks/metrics/flog.rake
@@ -7,40 +7,34 @@ namespace :metrics do
   project = Devtools.project
   config  = project.flog
 
-  if !config.enabled_platforms.include?(Devtools.rvm)
-    task :flog do
-      $stderr.puts "Flog is disabled under #{Devtools.rvm}"
+  # Original code by Marty Andrews:
+  # http://blog.martyandrews.net/2009/05/enforcing-ruby-code-quality.html
+  desc 'Measure code complexity'
+  task :flog do
+    threshold = config.threshold.to_f.round(1)
+    flog      = Flog.new
+    flog.flog(*FlogCLI.expand_dirs_to_files(config.lib_dirs))
+
+    totals = flog.totals.select  { |name, score| name[-5, 5] != '#none' }
+                        .map     { |name, score| [name, score.round(1)] }
+                        .sort_by { |name, score| score }
+
+    if totals.any?
+      max = totals.last[1]
+      unless max >= threshold
+        Devtools.notify_metric_violation "Adjust flog score down to #{max}"
+      end
     end
-  else
-    # Original code by Marty Andrews:
-    # http://blog.martyandrews.net/2009/05/enforcing-ruby-code-quality.html
-    desc 'Measure code complexity'
-    task :flog do
-      threshold = config.threshold.to_f.round(1)
-      flog      = Flog.new
-      flog.flog(*FlogCLI.expand_dirs_to_files(config.lib_dirs))
 
-      totals = flog.totals.select  { |name, score| name[-5, 5] != '#none' }
-                          .map     { |name, score| [name, score.round(1)] }
-                          .sort_by { |name, score| score }
-
-      if totals.any?
-        max = totals.last[1]
-        unless max >= threshold
-          Devtools.notify_metric_violation "Adjust flog score down to #{max}"
-        end
+    bad_methods = totals.select { |name, score| score > threshold }
+    if bad_methods.any?
+      bad_methods.reverse_each do |name, score|
+        printf "%8.1f: %s\n", score, name
       end
 
-      bad_methods = totals.select { |name, score| score > threshold }
-      if bad_methods.any?
-        bad_methods.reverse_each do |name, score|
-          printf "%8.1f: %s\n", score, name
-        end
-
-        Devtools.notify_metric_violation(
-          "#{bad_methods.size} methods have a flog complexity > #{threshold}"
-        )
-      end
+      Devtools.notify_metric_violation(
+        "#{bad_methods.size} methods have a flog complexity > #{threshold}"
+      )
     end
   end
 end

--- a/tasks/metrics/mutant.rake
+++ b/tasks/metrics/mutant.rake
@@ -1,23 +1,9 @@
 # encoding: utf-8
 
 namespace :metrics do
-  allowed_versions = %w[
-    mri-2.0.0
-    mri-2.1.0
-    mri-2.1.1
-    mri-2.1.2
-    mri-2.1.3
-    mri-2.1.4
-    mri-2.1.5
-    mri-2.2.0
-    mri-2.2.1
-    mri-2.2.2
-    mri-2.2.3
-  ].freeze
-
   config  = Devtools.project.mutant
 
-  if allowed_versions.include?(Devtools.rvm) && !ENV['DEVTOOLS_SELF']
+  if !ENV['DEVTOOLS_SELF']
     desc 'Measure mutation coverage'
     task mutant: :coverage do
       require 'mutant'


### PR DESCRIPTION
* Remove support for ruby 2.0.x
* The version guards where useful where devtools supported ruby versions
  that had different tooling behavior.
* Devtools right now supports ruby >= 2.1.0. All tools behave the "same"
  on these ruby versions. (flog flay scores are compatible, mutant works
  etc)
* For that reason the ruby version guards always evaluate to true and
  can be dropped.