### PR TITLE
Update reek to 3.3.1

### DIFF
--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'yard',         '~> 0.8.7.6'
   gem.add_dependency 'flay',         '~> 2.6.1'
   gem.add_dependency 'flog',         '~> 4.3.2'
-  gem.add_dependency 'reek',         '~> 3.2.1'
+  gem.add_dependency 'reek',         '~> 3.3.1'
   gem.add_dependency 'rubocop',      '~> 0.33.0'
   gem.add_dependency 'simplecov',    '~> 0.10.0'
   gem.add_dependency 'yardstick',    '~> 0.9.9'


### PR DESCRIPTION
Following up on #79, this bumps reek to the latest release ([reek v3.3.1](https://github.com/troessner/reek/releases/tag/v3.3.1)) which shouldn't break the build