### PR TITLE
Update mutant to 0.8.5

### DIFF
--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rubocop',      '~> 0.34.0'
   gem.add_runtime_dependency 'simplecov',    '~> 0.10.0'
   gem.add_runtime_dependency 'yardstick',    '~> 0.9.9'
-  gem.add_runtime_dependency 'mutant',       '~> 0.8.3'
+  gem.add_runtime_dependency 'mutant',       '~> 0.8.5'
   gem.add_runtime_dependency 'mutant-rspec', '~> 0.8.2'
 end


### PR DESCRIPTION
Currently:

```
Bundler could not find compatible versions for gem "anima":
  In Gemfile:
    devtools (>= 0) ruby depends on
      anima (~> 0.3.x) ruby

    devtools (>= 0) ruby depends on
      mutant (~> 0.8.3) ruby depends on
        anima (~> 0.2.0) ruby
```

this should fix the issue though