### PR TITLE
Remove redundant encoding comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 source 'https://rubygems.org'
 
 gemspec

--- a/bin/devtools
+++ b/bin/devtools
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
 
 require 'bundler'
 

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 Gem::Specification.new do |gem|
   gem.name        = 'devtools'
   gem.version     = '0.1.2'

--- a/lib/devtools.rb
+++ b/lib/devtools.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'pathname'
 require 'rake'
 require 'timeout'

--- a/lib/devtools/config.rb
+++ b/lib/devtools/config.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
 
   # Abstract base class of tool configuration

--- a/lib/devtools/platform.rb
+++ b/lib/devtools/platform.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
 
   # Provides methods to determine the ruby platform

--- a/lib/devtools/project.rb
+++ b/lib/devtools/project.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
 
   # The project devtools supports

--- a/lib/devtools/project/initializer.rb
+++ b/lib/devtools/project/initializer.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
   class Project
 

--- a/lib/devtools/project/initializer/rake.rb
+++ b/lib/devtools/project/initializer/rake.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
   class Project
     class Initializer

--- a/lib/devtools/project/initializer/rspec.rb
+++ b/lib/devtools/project/initializer/rspec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
   class Project
     class Initializer

--- a/lib/devtools/site.rb
+++ b/lib/devtools/site.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
 
   # Encapsulates a specific {Project} devtools is used for

--- a/lib/devtools/site/initializer.rb
+++ b/lib/devtools/site/initializer.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Devtools
   class Site
 

--- a/lib/devtools/spec_helper.rb
+++ b/lib/devtools/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'devtools'
 
 Devtools.init_spec_helper

--- a/shared/spec/shared/abstract_type_behavior.rb
+++ b/shared/spec/shared/abstract_type_behavior.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 shared_examples_for 'an abstract type' do
   context 'called on a subclass' do
     let(:object) { Class.new(described_class) }

--- a/shared/spec/shared/command_method_behavior.rb
+++ b/shared/spec/shared/command_method_behavior.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 shared_examples_for 'a command method' do
   it 'returns self' do
     should equal(object)

--- a/shared/spec/shared/each_method_behaviour.rb
+++ b/shared/spec/shared/each_method_behaviour.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 shared_examples_for 'an #each method' do
   it_should_behave_like 'a command method'
 

--- a/shared/spec/shared/hash_method_behavior.rb
+++ b/shared/spec/shared/hash_method_behavior.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 shared_examples_for 'a hash method' do
   it_should_behave_like 'an idempotent method'
 

--- a/shared/spec/shared/idempotent_method_behavior.rb
+++ b/shared/spec/shared/idempotent_method_behavior.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 shared_examples_for 'an idempotent method' do
   it 'is idempotent' do
     first = subject

--- a/shared/spec/support/ice_nine_config.rb
+++ b/shared/spec/support/ice_nine_config.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 if defined?(IceNine)
   module IceNine
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'devtools/spec_helper'
 
 if ENV['COVERAGE'] == 'true'

--- a/tasks/metrics/ci.rake
+++ b/tasks/metrics/ci.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 desc 'Run all specs, metrics and mutant'
 task ci: %w[spec ci:metrics metrics:mutant]
 

--- a/tasks/metrics/coverage.rake
+++ b/tasks/metrics/coverage.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 namespace :metrics do
   desc 'Measure code coverage'
   task :coverage do

--- a/tasks/metrics/flay.rake
+++ b/tasks/metrics/flay.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 namespace :metrics do
   require 'flay'
 

--- a/tasks/metrics/flog.rake
+++ b/tasks/metrics/flog.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 namespace :metrics do
   require 'flog'
   require 'flog_cli'

--- a/tasks/metrics/mutant.rake
+++ b/tasks/metrics/mutant.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 namespace :metrics do
   config  = Devtools.project.mutant
 

--- a/tasks/metrics/reek.rake
+++ b/tasks/metrics/reek.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 namespace :metrics do
   require 'reek/rake/task'
 

--- a/tasks/metrics/rubocop.rake
+++ b/tasks/metrics/rubocop.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 namespace :metrics do
   desc 'Check with code style guide'
   task :rubocop do

--- a/tasks/metrics/yardstick.rake
+++ b/tasks/metrics/yardstick.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 namespace :metrics do
   namespace :yardstick do
     require 'yardstick/rake/measurement'

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 begin
   require 'rspec/core/rake_task'
 

--- a/tasks/yard.rake
+++ b/tasks/yard.rake
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 begin
   require 'yard'
 


### PR DESCRIPTION
* Devtools does not support rubies anymore where the default encoding is
  not utf-8