### PR TITLE
Fix build shield to use circleci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devtools
 
-[![Build Status](https://secure.travis-ci.org/mbj/devtools.png?branch=master)](http://travis-ci.org/mbj/devtools)
+[![Build Status](https://img.shields.io/circleci/project/mbj/devtools.svg)](https://circleci.com/gh/mbj/devtools/tree/master)
 [![Dependency Status](https://gemnasium.com/mbj/devtools.png)](https://gemnasium.com/mbj/devtools)
 [![Code Climate](https://codeclimate.com/github/datamapper/devtools.png)](https://codeclimate.com/github/datamapper/devtools)
 <!-- [![Code Climate](https://codeclimate.com/github/mbj/devtools.png)](https://codeclimate.com/github/mbj/devtools) -->


### PR DESCRIPTION
The codeclimate badge is still pointing to datamapper too but it looks like changing that results in the badge not resolving to a valid url