### PR TITLE
Upgrade mutant dependency to 0.8.9 

### DIFF
--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rubocop',      '~> 0.35.1'
   gem.add_runtime_dependency 'simplecov',    '~> 0.10.0'
   gem.add_runtime_dependency 'yardstick',    '~> 0.9.9'
-  gem.add_runtime_dependency 'mutant',       '~> 0.8.8'
+  gem.add_runtime_dependency 'mutant',       '~> 0.8.9'
   gem.add_runtime_dependency 'mutant-rspec', '~> 0.8.8'
 end

--- a/tasks/metrics/mutant.rake
+++ b/tasks/metrics/mutant.rake
@@ -19,6 +19,8 @@ namespace :metrics do
       %W[--ignore #{matcher}]
     end
 
+    jobs = ENV.key?('CIRCLECI') ? %w[--jobs 4] : []
+
     since =
       if config.since
         %W[--since #{config.since}]
@@ -31,11 +33,10 @@ namespace :metrics do
       --require #{config.name}
       --expect-coverage #{config.expect_coverage}
       --use #{config.strategy}
-    ].concat(ignore_subjects).concat(namespaces).concat(since)
+    ].concat(ignore_subjects).concat(namespaces).concat(since).concat(jobs)
 
-    status = namespace::CLI.run(arguments)
-    if status.nonzero?
-      Devtools.notify_metric_violation 'Mutant task is not successful'
+    unless namespace::CLI.run(arguments)
+      Devtools.notify_metric_violation('Mutant task is not successful')
     end
   end
 end


### PR DESCRIPTION
- Changes mutant task to conform with changes to return value
  of `Mutant::CLI.run`

- Adds check for circle ci in mutant rake

  - Mutant is currently defaulting to 32 jobs on circle. When on
    circle ci this should be 4 jobs. Mutant used to handle this
    until 0.8.9