### PR TITLE
Update rubocop and reek

### DIFF
--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'flay',         '~> 2.7.0'
   gem.add_runtime_dependency 'flog',         '~> 4.3.2'
   gem.add_runtime_dependency 'reek',         '~> 3.11.0'
-  gem.add_runtime_dependency 'rubocop',      '~> 0.37.2'
+  gem.add_runtime_dependency 'rubocop',      '~> 0.38.0'
   gem.add_runtime_dependency 'simplecov',    '~> 0.10.0'
   gem.add_runtime_dependency 'yardstick',    '~> 0.9.9'
   gem.add_runtime_dependency 'mutant',       '~> 0.8.10'

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'yard',         '~> 0.8.7.6'
   gem.add_runtime_dependency 'flay',         '~> 2.7.0'
   gem.add_runtime_dependency 'flog',         '~> 4.3.2'
-  gem.add_runtime_dependency 'reek',         '~> 3.10.2'
+  gem.add_runtime_dependency 'reek',         '~> 3.11.0'
   gem.add_runtime_dependency 'rubocop',      '~> 0.37.2'
   gem.add_runtime_dependency 'simplecov',    '~> 0.10.0'
   gem.add_runtime_dependency 'yardstick',    '~> 0.9.9'


### PR DESCRIPTION
Thoughts on this branch name? [I've opened about 10 dependency update PRs](https://github.com/mbj/devtools/pulls?utf8=%E2%9C%93&q=is%3Aclosed+is%3Apr+author%3Abackus+) so far and it usually isn't obvious how to name them uniquely. I think adopting something like `update/dependencies/march-2016` might be nice