### PR TITLE
Bump version to 0.1.9

### DIFF
--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'devtools'
-  gem.version     = '0.1.8'
+  gem.version     = '0.1.9'
   gem.authors     = [ 'Markus Schirp' ]
   gem.email       = [ 'mbj@schirp-dso.com' ]
   gem.description = 'A metagem wrapping development tools'


### PR DESCRIPTION
As mentioned in slack:

> **backus [2:09]**
> 
> 
> ```
> gem.add_runtime_dependency 'rspec',        '=  3.4.0'  # blocked by mutant-rspec
> gem.add_runtime_dependency 'rspec-core',   '=  3.4.4'  # blocked by mutant-rspec
> ```
> 
> **backus [2:09]**
> 
> master for mutant supports 3.5
> 
> **backus [2:09]**
> 
> so we could also just coordinate a mutant release

but if it would take a day or two to asynchronously coordinate a mutant release before a devtools release then it might be more expedient to just do two quick releases of devtools