### PR TITLE
Remove mutant integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - checkout
       - run: bundle install
-      - run: bundle exec mutant --since origin/master -- 'Devtools*'
+      - run: bundle exec mutant --since HEAD~1 -- 'Devtools*'
 workflows:
   version: 2
   test:

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'mutant', git: 'https://github.com/mbj/mutant.git'
+gem(
+  'mutant',
+  git: 'https://github.com/mbj/mutant.git',
+  ref: 'b55665b8ad5983760c38b3ab8c8a0e2c2fe97c1d'
+)

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'simplecov',     '~> 0.16.1'
   gem.add_runtime_dependency 'yard',          '~> 0.9.16'
   gem.add_runtime_dependency 'yardstick',     '~> 0.9.9'
+
+  gem.add_development_dependency 'mutant', '~> 0.8.24'
 end


### PR DESCRIPTION
* Mutant now has its own config file, so no need to include it in
  devtools.