### PR TITLE
Remove ruby version constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,11 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem(
-  'mutant',
-  git: 'https://github.com/mbj/mutant.git',
-  branch: 'add/parser-2.7-support'
-)
+group :development do
+  gem 'mutant'
+  gem 'mutant-rspec'
 
-source 'https://oss:Px2ENN7S91OmWaD5G7MIQJi1dmtmYrEh@gem.mutant.dev' do
-  gem 'mutant-license'
+  source 'https://oss:Px2ENN7S91OmWaD5G7MIQJi1dmtmYrEh@gem.mutant.dev' do
+    gem 'mutant-license'
+  end
 end

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -8,12 +8,11 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'https://github.com/rom-rb/devtools'
   gem.license     = 'MIT'
 
-  gem.require_paths         = %w[lib]
-  gem.files                 = `git ls-files`.split("\n")
-  gem.executables           = %w[]
-  gem.test_files            = `git ls-files -- spec`.split("\n")
-  gem.extra_rdoc_files      = %w[README.md]
-  gem.required_ruby_version = '>= 2.5'
+  gem.require_paths    = %w[lib]
+  gem.files            = `git ls-files`.split("\n")
+  gem.executables      = %w[]
+  gem.test_files       = `git ls-files -- spec`.split("\n")
+  gem.extra_rdoc_files = %w[README.md]
 
   gem.add_runtime_dependency 'abstract_type', '~> 0.0.7'
   gem.add_runtime_dependency 'adamantium',    '~> 0.2.0'

--- a/devtools.gemspec
+++ b/devtools.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'devtools'
-  gem.version     = '0.1.25'
+  gem.version     = '0.1.26'
   gem.authors     = ['Markus Schirp']
   gem.email       = ['mbj@schirp-dso.com']
   gem.description = 'A metagem wrapping development tools'


### PR DESCRIPTION
* There are projects that support really old rubies. But wish to use
  devtools on their recent rubies.
* This is a development tool so I expect that people take care to not
  run on the bundled tools on older rubies where the results are
  inconsistent / or the tools are simply crashing.